### PR TITLE
Fix setting default level background color

### DIFF
--- a/korge-ldtk/src/commonMain/kotlin/korlibs/korge/ldtk/view/LDTKView.kt
+++ b/korge-ldtk/src/commonMain/kotlin/korlibs/korge/ldtk/view/LDTKView.kt
@@ -163,7 +163,7 @@ class LDTKLevelView(
     private val _layerViews = arrayListOf<View>()
     private val _layerViewsByName = linkedHashMapOf<String, View>()
 
-    val bgLayer = solidRect(blevel.pxWid, blevel.pxHei, Colors[blevel.levelBgColor ?: ldtk.bgColor]).also {
+    val bgLayer = solidRect(blevel.pxWid, blevel.pxHei, Colors[blevel.levelBgColor ?: ldtk.defaultLevelBgColor]).also {
         it.name = "background"
     }
     val layerViews = level.layers.asReversed().map { layer -> LDTKLayerView(layer, showCollisions).addTo(this) }


### PR DESCRIPTION
Use `defaultLevelBgColor` instead of `bgColor`. `bgColor` is specifying the background color for the level in the LDtk editor, which is not a color which we want for the final game level.