### PR TITLE
Make rendering of background color optional

### DIFF
--- a/korge-ldtk/src/commonMain/kotlin/korlibs/korge/ldtk/view/LDTKView.kt
+++ b/korge-ldtk/src/commonMain/kotlin/korlibs/korge/ldtk/view/LDTKView.kt
@@ -154,7 +154,8 @@ class LDTKLayerView(
 
 class LDTKLevelView(
     val level: LDTKLevel,
-    var showCollisions: Boolean = false
+    private var showCollisions: Boolean = false,
+    private var showBackground: Boolean = true
 ) : Container() {
     private val ldtk get() = level.ldtk
     private val world get() = level.world
@@ -165,6 +166,7 @@ class LDTKLevelView(
 
     val bgLayer = solidRect(blevel.pxWid, blevel.pxHei, Colors[blevel.levelBgColor ?: ldtk.defaultLevelBgColor]).also {
         it.name = "background"
+        it.visible = showBackground
     }
     val layerViews = level.layers.asReversed().map { layer -> LDTKLayerView(layer, showCollisions).addTo(this) }
     val layerViewsByName = layerViews.associateBy { it.layer.identifier }
@@ -172,11 +174,12 @@ class LDTKLevelView(
 
 class LDTKWorldView(
     val world: LDTKWorld,
-    var showCollisions: Boolean = false
+    showCollisions: Boolean = false,
+    showBackground: Boolean = true
 ) : Container() {
     init {
         for (level in world.levels) {
-            LDTKLevelView(level, showCollisions)
+            LDTKLevelView(level, showCollisions, showBackground)
                 .addTo(this)
                 .xy(level.level.worldX, level.level.worldY)
         }


### PR DESCRIPTION
LDtk level view always renders the background color as a solidRect. But sometimes it is needed that a level map view is opaque because e.g. some other background objects behind the level map should be visible like parallax layers.

This commit adds an option to disable rendering of the soldRect for the background color.