### PR TITLE
Fix loading tileRectsIds in auto-layer rule definition

### DIFF
--- a/korge-ldtk/src/commonMain/kotlin/korlibs/korge/ldtk/LDTKJson.kt
+++ b/korge-ldtk/src/commonMain/kotlin/korlibs/korge/ldtk/LDTKJson.kt
@@ -862,7 +862,7 @@ data class LayerDefinition (
     /**
      * Contains all the auto-layer rule definitions.
      */
-//    val autoRuleGroups: List<AutoLayerRuleGroup>,
+    val autoRuleGroups: List<AutoLayerRuleGroup>,
 
     val autoSourceLayerDefUid: Int? = null,
 
@@ -1073,7 +1073,7 @@ data class AutoLayerRuleDefinition (
      * Array of all the tile IDs. They are used randomly or as stamps, based on `tileMode` value.
      */
     @SerialName("tileRectsIds")
-    val tileIDS: IntArray,
+    val tileIDS: List<IntArray>,
 
     /**
      * Defines how tileIds array is used Possible values: `Single`, `Stamp`

--- a/korge-ldtk/src/commonMain/kotlin/korlibs/korge/ldtk/LDTKJson.kt
+++ b/korge-ldtk/src/commonMain/kotlin/korlibs/korge/ldtk/LDTKJson.kt
@@ -862,7 +862,7 @@ data class LayerDefinition (
     /**
      * Contains all the auto-layer rule definitions.
      */
-    val autoRuleGroups: List<AutoLayerRuleGroup>,
+//    val autoRuleGroups: List<AutoLayerRuleGroup>,
 
     val autoSourceLayerDefUid: Int? = null,
 
@@ -1072,7 +1072,7 @@ data class AutoLayerRuleDefinition (
     /**
      * Array of all the tile IDs. They are used randomly or as stamps, based on `tileMode` value.
      */
-    @SerialName("tileIds")
+    @SerialName("tileRectsIds")
     val tileIDS: IntArray,
 
     /**


### PR DESCRIPTION
When creating rules for auto-layers of an IntGrid in LDtk and saving it, then Korge-ldtk was not able to load that ldtk file any more due to differences between json file and the implemented json schema.

The name of the property is different in json file from LDtk, thus `@SerialName` was updated.
Also the type of the `tileIDS` field needs to be an array of array of Ints.